### PR TITLE
Add CRUD for Vaults

### DIFF
--- a/src/components/ApiTest.jsx
+++ b/src/components/ApiTest.jsx
@@ -26,7 +26,7 @@ const ApiTest = () => {
         requiredFields: ['topic']
       };
       const input = { topic: 'test topic' };
-      const prompt = await generatePrompt(template, input);
+      const { prompt }= await generatePrompt(template, input);
       setResults(prompt);
     } catch (error) {
       setResults(`Error: ${error.message}`);

--- a/src/components/Playground.jsx
+++ b/src/components/Playground.jsx
@@ -17,10 +17,12 @@ const Playground = () => {
     generatedContent,
     activeTab,
     isLoading,
+    vaultId,
     setCurrentInput,
     setGeneratedPrompt,
     setRefinedPrompt,
     setGeneratedContent,
+    setVaultId,
     setActiveTab,
     setIsLoading,
     saveCurrentSession,
@@ -246,8 +248,9 @@ const Playground = () => {
 
     setIsLoading(true);
     try {
-      const prompt = await generatePrompt(currentTemplate, currentInput);
+      const { prompt, vaultId } = await generatePrompt(currentTemplate, currentInput);
       setGeneratedPrompt(prompt);
+      setVaultId(vaultId);
       setEditablePrompt(prompt);
       saveCurrentSession();
       toast.success('Prompt generated successfully!');
@@ -265,7 +268,7 @@ const Playground = () => {
 
     setIsLoading(true);
     try {
-      const refined = await refinePrompt(type, promptToRefine);
+      const refined = await refinePrompt(type, promptToRefine, vaultId);
       setRefinedPrompt(refined);
       setEditableRefinedPrompt(refined);
       saveCurrentSession();
@@ -309,7 +312,7 @@ const Playground = () => {
 
     setIsLoading(true);
     try {
-      const content = await generateAIContent(promptToUse, useRefinedPrompt);
+      const content = await generateAIContent(promptToUse, useRefinedPrompt, vaultId);
       setGeneratedContent(content);
       setEditableContent(content);
       saveCurrentSession();
@@ -328,7 +331,7 @@ const Playground = () => {
 
     setIsLoading(true);
     try {
-      const refined = await refineContent(type, contentToRefine);
+      const refined = await refineContent(type, contentToRefine, vaultId);
       setGeneratedContent(refined);
       setEditableContent(refined);
       saveCurrentSession();

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -61,39 +61,42 @@ export async function generatePrompt(template, input) {
     }),
   });
 
-  return response.prompt;
+  return { prompt: response.prompt, vaultId: response.vaultId };
 }
 
-export async function refinePrompt(type, prompt) {
+export async function refinePrompt(type, prompt, vaultId) {
   const response = await apiCall("/refine/prompt", {
     method: "POST",
     body: JSON.stringify({
       prompt,
       refinementType: type,
+      vaultId,
     }),
   });
 
   return response.refinedPrompt;
 }
 
-export async function generateAIContent(prompt, isRefined = false) {
+export async function generateAIContent(prompt, isRefined = false, vaultId) {
   const response = await apiCall("/ai-generate", {
     method: "POST",
     body: JSON.stringify({
       text: prompt,
       isRefinedPrompt: isRefined,
+      vaultId,
     }),
   });
 
   return response.result;
 }
 
-export async function refineContent(type, content) {
+export async function refineContent(type, content, vaultId) {
   const response = await apiCall("/refine/content", {
     method: "POST",
     body: JSON.stringify({
       content,
       refinementType: type,
+      vaultId,
     }),
   });
 

--- a/src/store/playgroundStore.js
+++ b/src/store/playgroundStore.js
@@ -13,6 +13,7 @@ export const usePlaygroundStore = create()(
       activeTab: 'form',
       isLoading: false,
       sessions: [],
+      vaultId: null,
 
       // Actions
       setCurrentTemplate: (template) => set({ 
@@ -23,6 +24,8 @@ export const usePlaygroundStore = create()(
         generatedContent: null,
         activeTab: 'form'
       }),
+
+      setVaultId: (vaultId) => set({ vaultId }),
 
       setCurrentInput: (input) => set({ currentInput: input }),
 
@@ -58,6 +61,7 @@ export const usePlaygroundStore = create()(
           refinedPrompt: state.refinedPrompt || undefined,
           generatedContent: state.generatedContent || undefined,
           createdAt: new Date().toISOString(),
+          vaultId: state.vaultId || null, // Optional vaultId if needed
         };
 
         set(state => ({


### PR DESCRIPTION
After user generate a prompt from templates, a vault will be created, we can consider it's data for an session.
Vaults are stored as an obj contains initial `generated prompt`, `refined prompt`, `generated content`. 
`Refined prompt` & `Generated content` are also stored as versions (represent each user's action) in history field.

**Flow:**
User generate prompt -> Create vault with `initialPrompt`, return `vaultId` to frontend
User refine prompt or generate/refine content -> update vault with coresponding field (`refinedPrompt` or `generatedContent`), also update `history` as a new version with that field and action (`refine-prompt` or `generate-content`)

<img width="1009" height="724" alt="image" src="https://github.com/user-attachments/assets/d2dedf91-a599-42ec-9f41-d9688c6c9545" />
